### PR TITLE
Revert "Ensure Quick Battle leaderboard uses configured Supabase project"

### DIFF
--- a/services/supabaseClient.ts
+++ b/services/supabaseClient.ts
@@ -111,7 +111,7 @@ export async function fetchBattlesFromSupabase(): Promise<BattleSummary[] | null
 
 export async function fetchQuickBattleLeaderboardFromDB(): Promise<QuickBattleLeaderboardEntry[] | null> {
   try {
-    // Try the view first
+    // Try the public view
     const { data: viewData, error: viewError } = await supabase
       .from('v_quick_battle_leaderboard_public')
       .select('*')


### PR DESCRIPTION
Reverts CandyToyBox/analytics-wave-warz#43

the screen is blank the site doesnt even load! 
