### PR TITLE
Update Edge Function URLs to new endpoint

### DIFF
--- a/supabase/functions/leaderboard-refresh/index.ts
+++ b/supabase/functions/leaderboard-refresh/index.ts
@@ -1,0 +1,44 @@
+// ============================================================================
+// LEADERBOARD REFRESH - REDIRECT TO BATTLES WEBHOOK
+// ============================================================================
+// This edge function redirects all requests to the new battles-webhook endpoint
+// URL: https://gshwqoplsxgqbdkssoit.supabase.co/functions/v1/battles-webhook
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+
+const BATTLES_WEBHOOK_URL = 'https://gshwqoplsxgqbdkssoit.supabase.co/functions/v1/battles-webhook';
+
+serve(async (req) => {
+  try {
+    console.log('🔄 Redirecting leaderboard-refresh request to battles-webhook');
+
+    // Forward the request to the battles-webhook endpoint
+    const response = await fetch(BATTLES_WEBHOOK_URL, {
+      method: req.method,
+      headers: req.headers,
+      body: req.method !== 'GET' && req.method !== 'HEAD' ? await req.text() : undefined,
+    });
+
+    // Get the response body
+    const body = await response.text();
+
+    // Return the response from battles-webhook
+    return new Response(body, {
+      status: response.status,
+      headers: response.headers,
+    });
+  } catch (error) {
+    console.error('❌ Error redirecting to battles-webhook:', error);
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: 'Failed to redirect to battles-webhook',
+        message: error.message
+      }),
+      {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    );
+  }
+});

--- a/supabase/functions/quick-battles-sync/index.ts
+++ b/supabase/functions/quick-battles-sync/index.ts
@@ -1,0 +1,44 @@
+// ============================================================================
+// QUICK BATTLES SYNC - REDIRECT TO BATTLES WEBHOOK
+// ============================================================================
+// This edge function redirects all requests to the new battles-webhook endpoint
+// URL: https://gshwqoplsxgqbdkssoit.supabase.co/functions/v1/battles-webhook
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+
+const BATTLES_WEBHOOK_URL = 'https://gshwqoplsxgqbdkssoit.supabase.co/functions/v1/battles-webhook';
+
+serve(async (req) => {
+  try {
+    console.log('🔄 Redirecting quick-battles-sync request to battles-webhook');
+
+    // Forward the request to the battles-webhook endpoint
+    const response = await fetch(BATTLES_WEBHOOK_URL, {
+      method: req.method,
+      headers: req.headers,
+      body: req.method !== 'GET' && req.method !== 'HEAD' ? await req.text() : undefined,
+    });
+
+    // Get the response body
+    const body = await response.text();
+
+    // Return the response from battles-webhook
+    return new Response(body, {
+      status: response.status,
+      headers: response.headers,
+    });
+  } catch (error) {
+    console.error('❌ Error redirecting to battles-webhook:', error);
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: 'Failed to redirect to battles-webhook',
+        message: error.message
+      }),
+      {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    );
+  }
+});

--- a/supabase/functions/refresh-quick-battles-leaderboard/index.ts
+++ b/supabase/functions/refresh-quick-battles-leaderboard/index.ts
@@ -1,0 +1,44 @@
+// ============================================================================
+// REFRESH QUICK BATTLES LEADERBOARD - REDIRECT TO BATTLES WEBHOOK
+// ============================================================================
+// This edge function redirects all requests to the new battles-webhook endpoint
+// URL: https://gshwqoplsxgqbdkssoit.supabase.co/functions/v1/battles-webhook
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+
+const BATTLES_WEBHOOK_URL = 'https://gshwqoplsxgqbdkssoit.supabase.co/functions/v1/battles-webhook';
+
+serve(async (req) => {
+  try {
+    console.log('🔄 Redirecting refresh-quick-battles-leaderboard request to battles-webhook');
+
+    // Forward the request to the battles-webhook endpoint
+    const response = await fetch(BATTLES_WEBHOOK_URL, {
+      method: req.method,
+      headers: req.headers,
+      body: req.method !== 'GET' && req.method !== 'HEAD' ? await req.text() : undefined,
+    });
+
+    // Get the response body
+    const body = await response.text();
+
+    // Return the response from battles-webhook
+    return new Response(body, {
+      status: response.status,
+      headers: response.headers,
+    });
+  } catch (error) {
+    console.error('❌ Error redirecting to battles-webhook:', error);
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: 'Failed to redirect to battles-webhook',
+        message: error.message
+      }),
+      {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    );
+  }
+});

--- a/supabase/functions/update-quick-battle-refresh/index.ts
+++ b/supabase/functions/update-quick-battle-refresh/index.ts
@@ -1,0 +1,44 @@
+// ============================================================================
+// UPDATE QUICK BATTLE REFRESH - REDIRECT TO BATTLES WEBHOOK
+// ============================================================================
+// This edge function redirects all requests to the new battles-webhook endpoint
+// URL: https://gshwqoplsxgqbdkssoit.supabase.co/functions/v1/battles-webhook
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+
+const BATTLES_WEBHOOK_URL = 'https://gshwqoplsxgqbdkssoit.supabase.co/functions/v1/battles-webhook';
+
+serve(async (req) => {
+  try {
+    console.log('🔄 Redirecting update-quick-battle-refresh request to battles-webhook');
+
+    // Forward the request to the battles-webhook endpoint
+    const response = await fetch(BATTLES_WEBHOOK_URL, {
+      method: req.method,
+      headers: req.headers,
+      body: req.method !== 'GET' && req.method !== 'HEAD' ? await req.text() : undefined,
+    });
+
+    // Get the response body
+    const body = await response.text();
+
+    // Return the response from battles-webhook
+    return new Response(body, {
+      status: response.status,
+      headers: response.headers,
+    });
+  } catch (error) {
+    console.error('❌ Error redirecting to battles-webhook:', error);
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: 'Failed to redirect to battles-webhook',
+        message: error.message
+      }),
+      {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    );
+  }
+});

--- a/supabase/functions/update-quick-battle/index.ts
+++ b/supabase/functions/update-quick-battle/index.ts
@@ -1,0 +1,44 @@
+// ============================================================================
+// UPDATE QUICK BATTLE - REDIRECT TO BATTLES WEBHOOK
+// ============================================================================
+// This edge function redirects all requests to the new battles-webhook endpoint
+// URL: https://gshwqoplsxgqbdkssoit.supabase.co/functions/v1/battles-webhook
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+
+const BATTLES_WEBHOOK_URL = 'https://gshwqoplsxgqbdkssoit.supabase.co/functions/v1/battles-webhook';
+
+serve(async (req) => {
+  try {
+    console.log('🔄 Redirecting update-quick-battle request to battles-webhook');
+
+    // Forward the request to the battles-webhook endpoint
+    const response = await fetch(BATTLES_WEBHOOK_URL, {
+      method: req.method,
+      headers: req.headers,
+      body: req.method !== 'GET' && req.method !== 'HEAD' ? await req.text() : undefined,
+    });
+
+    // Get the response body
+    const body = await response.text();
+
+    // Return the response from battles-webhook
+    return new Response(body, {
+      status: response.status,
+      headers: response.headers,
+    });
+  } catch (error) {
+    console.error('❌ Error redirecting to battles-webhook:', error);
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: 'Failed to redirect to battles-webhook',
+        message: error.message
+      }),
+      {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    );
+  }
+});


### PR DESCRIPTION
Added 5 Supabase Edge Functions that redirect legacy endpoints to the new battles-webhook:
- leaderboard-refresh
- quick-battles-sync
- refresh-quick-battles-leaderboard
- update-quick-battle
- update-quick-battle-refresh

All functions now proxy requests to https://gshwqoplsxgqbdkssoit.supabase.co/functions/v1/battles-webhook

This consolidation simplifies the webhook architecture by having a single central endpoint handle all battle-related webhook events.