### PR TITLE
Optimize quick battles leaderboard computation

### DIFF
--- a/hooks/useBattleData.ts
+++ b/hooks/useBattleData.ts
@@ -161,6 +161,37 @@ export function useQuickBattleLeaderboard() {
   return useQuery<QuickBattleLeaderboardEntry[]>({
     queryKey: ['leaderboard', 'quickBattles'],
     queryFn: async () => (await fetchQuickBattleLeaderboardFromDB()) ?? [],
-    staleTime: 60000,
+    staleTime: 15000, // 15 seconds for testing - increase to 60000 (60s) for production
   });
+}
+
+/**
+ * Hook to refresh all leaderboard data by invalidating React Query caches
+ * This forces refetch of fresh data from the database
+ */
+export function useRefreshLeaderboards() {
+  const queryClient = useQueryClient();
+
+  return {
+    refreshQuickBattles: async () => {
+      console.log('🔄 Invalidating quick battles leaderboard cache...');
+      await queryClient.invalidateQueries({ queryKey: ['leaderboard', 'quickBattles'] });
+      console.log('✅ Quick battles leaderboard cache invalidated');
+    },
+    refreshArtists: async () => {
+      console.log('🔄 Invalidating artist leaderboard cache...');
+      await queryClient.invalidateQueries({ queryKey: ['leaderboard', 'artists'] });
+      console.log('✅ Artist leaderboard cache invalidated');
+    },
+    refreshTraders: async () => {
+      console.log('🔄 Invalidating trader leaderboard cache...');
+      await queryClient.invalidateQueries({ queryKey: ['leaderboard', 'traders'] });
+      console.log('✅ Trader leaderboard cache invalidated');
+    },
+    refreshAll: async () => {
+      console.log('🔄 Invalidating all leaderboard caches...');
+      await queryClient.invalidateQueries({ queryKey: ['leaderboard'] });
+      console.log('✅ All leaderboard caches invalidated');
+    },
+  };
 }


### PR DESCRIPTION
… refresh

Implemented Supabase AI recommendations for the quick battles leaderboard:

1. Multi-level ordering - Sort by total_volume_generated, wins, then last_battle_date to ensure consistent ranking when volumes are equal (fixes "29 entries" issue)

2. Explicit column selection - Use explicit column names instead of SELECT * for better performance and clarity

3. Cache invalidation - Added useRefreshLeaderboards() hook and refresh button to manually invalidate React Query cache and refetch fresh data

4. Reduced staleTime - Changed from 60s to 15s for testing to verify data freshness (can be increased to 60s for production)

5. Enhanced logging - Added detailed console logging throughout the data flow to track which data source is used (table/view/fallback) and debug issues

The leaderboard now properly sorts entries and provides a manual refresh mechanism for users to see the latest data from the database.